### PR TITLE
Change User resource id from username to email.

### DIFF
--- a/docs/resources/airflow_user.md
+++ b/docs/resources/airflow_user.md
@@ -23,25 +23,44 @@ resource "airflow_user" "example" {
 }
 ```
 
+### GCP Cloud Composer
+
+It is possible to create Airflow users when using Cloud Composer by [using the primary e-mail as the username](https://cloud.google.com/composer/docs/composer-2/airflow-rbac#registering-users). Upon first login, GCP with replace the username with a GCP user Id (formatted like `accounts.google.com:<12345678...>`). Because of this, Terraform will try to update this user during the next `apply`, which forces replacement of the complete user. To prevent this from happening, ignore any changes to the username using the `lifecycle` meta argument.
+
+```hcl
+resource "airflow_user" "user" {
+  email      = "user@email.com"
+  first_name = "user@email.com"
+  last_name  = "-"
+  username   = "user@email.com"
+  password   = ""
+  roles      = [airflow_role.example.name]
+
+  lifecycle {
+    ignore_changes = [username]
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
-* `email` - (Required) The user's email
-* `first_name` - (Required) The user firstname
-* `last_name` - (Required) The user lastname
-* `username` - (Required) The username
-* `password` - (Required) The user password.
-* `roles` - (Required) A set of User roles to attach to the User.
+- `email` - (Required) The user's email
+- `first_name` - (Required) The user firstname
+- `last_name` - (Required) The user lastname
+- `username` - (Required) The username
+- `password` - (Required) The user password.
+- `roles` - (Required) A set of User roles to attach to the User.
 
 ## Attributes Reference
 
 This resource exports the following attributes:
 
-* `active` - Whether the user is active.
-* `id` - The username.
-* `failed_login_count` - The number of times the login failed.
-* `login_count` - The login count.
+- `active` - Whether the user is active.
+- `id` - The username.
+- `failed_login_count` - The number of times the login failed.
+- `login_count` - The login count.
 
 ## Import
 


### PR DESCRIPTION
Reason is that GCP Cloud Composer changes username upon first
user login. This makes Terraform think that the user has been
deleted. An Airflow user is not only unique by its username but
also e-mail. So changing the Terraform user id to e-mail fixes
is safe.

*note*: I don't have any prior Go experience so excuse me for any non-idiomatic Go use. Happy to update!