### PR TITLE
Support airflow api on paths instead of just domain

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"strings"
 
 	"github.com/apache/airflow-client-go/airflow"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -90,13 +91,15 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		authCtx = context.WithValue(authCtx, airflow.ContextBasicAuth, cred)
 	}
 
+	path := strings.TrimRight(u.Path, "/")
+
 	clientConf := &airflow.Configuration{
 		Scheme: u.Scheme,
 		Host:   u.Host,
 		Debug:  true,
 		Servers: airflow.ServerConfigurations{
 			{
-				URL:         "/api/v1",
+				URL:         fmt.Sprint(path, "/api/v1"),
 				Description: "Apache Airflow Stable API.",
 			},
 		},


### PR DESCRIPTION
Airflow api is most often below
example.com/api/v1

but because of proxy or so, it can be also below
example.com/project/api/v1
so one has to enter base_endpoint as "example.com/project"

That didn't work before my commit and works with my commit.