### PR TITLE
Fix password_wo not applied on create

### DIFF
--- a/internal/provider/resource_connection.go
+++ b/internal/provider/resource_connection.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/apache/airflow-client-go/airflow"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -233,8 +234,16 @@ func resourceConnectionCreate(ctx context.Context, d *schema.ResourceData, m int
 
 	if v, ok := d.GetOk("password"); ok {
 		conn.SetPassword(v.(string))
-	} else if v, ok := d.GetOk("password_wo"); ok {
-		conn.SetPassword(v.(string))
+	} else {
+		woVal, woDiags := d.GetRawConfigAt(cty.GetAttrPath("password_wo"))
+		if woDiags.HasError() {
+			return woDiags
+		}
+		if !woVal.IsNull() && woVal.Type().Equals(cty.String) {
+			if pw := woVal.AsString(); pw != "" {
+				conn.SetPassword(pw)
+			}
+		}
 	}
 
 	if v, ok := d.GetOk("extra"); ok {
@@ -368,8 +377,16 @@ func resourceConnectionUpdate(ctx context.Context, d *schema.ResourceData, m int
 
 	if v, ok := d.GetOk("password"); ok && v.(string) != "" {
 		conn.SetPassword(v.(string))
-	} else if v, ok := d.GetOk("password_wo"); ok && v.(string) != "" {
-		conn.SetPassword(v.(string))
+	} else if d.HasChange("password_wo_version") {
+		woVal, woDiags := d.GetRawConfigAt(cty.GetAttrPath("password_wo"))
+		if woDiags.HasError() {
+			return woDiags
+		}
+		if !woVal.IsNull() && woVal.Type().Equals(cty.String) {
+			if pw := woVal.AsString(); pw != "" {
+				conn.SetPassword(pw)
+			}
+		}
 	}
 
 	if v, ok := d.GetOk("extra"); ok {


### PR DESCRIPTION
  - Import: added "github.com/hashicorp/go-cty/cty" (already an indirect dep via the SDK)                                                
  - Create: replaced d.GetOk("password_wo") with d.GetRawConfigAt(cty.GetAttrPath("password_wo")) - reads from the raw Terraform config which carries ephemeral values                                                                                                         
  - Update: same replacement, but gated behind d.HasChange("password_wo_version") — password is only pushed to Airflow when the version trigger is explicitly bumped, which is the intended semantics of the write-only pattern 
 - The problem: d.GetOk() reads from Terraform state. Write-only attributes (WriteOnly: true) are never written to state by design, that's the whole point of them. So d.GetOk("password_wo") always returns (nil, false), regardless of what value the user provided. The connection was created with no password.                                                                                                                                                                          
 - The fix: d.GetRawConfigAt() reads from the raw configuration that Terraform sends the provider during apply. That payload includes write-only and ephemeral values — they exist there, they're just never persisted afterward. So this is the correct read path for any WriteOnly: true attribute.

 - The version gate on Update: The password_wo_version field exists specifically as a trigger — the user bumps it when they want to rotate the password. Without the d.HasChange("password_wo_version") gate, the provider would re-push the password on every update regardless of whether the user intended to rotate it (e.g. changing host would also silently re-push the password). With the gate, the password is only sent to Airflow when the version actually changed.