### PR TITLE
feat: add session_cookie auth for AWS MWAA private environments

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -67,6 +67,14 @@ func AirflowProvider() *schema.Provider {
 				Description: "Base path for Airflow API endpoints",
 				DefaultFunc: schema.EnvDefaultFunc("AIRFLOW_API_BASE_PATH", "/api/v1"),
 			},
+			"session_cookie": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Sensitive:     true,
+				Description:   "A session cookie value to use for authentication (sent as Cookie: session=<value>). Useful for AWS MWAA private environments.",
+				DefaultFunc:   schema.EnvDefaultFunc("AIRFLOW_SESSION_COOKIE", nil),
+				ConflictsWith: []string{"oauth2_token", "username", "password"},
+			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"airflow_connection": resourceConnection(),
@@ -130,11 +138,18 @@ func providerConfigure(_ context.Context, d *schema.ResourceData) (interface{}, 
 
 	path := strings.TrimSuffix(u.Path, "/")
 
+	defaultHeaders := map[string]string{}
+	if v, ok := d.GetOk("session_cookie"); ok {
+		defaultHeaders["Cookie"] = fmt.Sprintf("session=%s", v.(string))
+		log.Printf("[DEBUG] Using session cookie authentication")
+	}
+
 	clientConf := &airflow.Configuration{
-		Scheme:     u.Scheme,
-		Host:       u.Host,
-		Debug:      true,
-		HTTPClient: client,
+		Scheme:        u.Scheme,
+		Host:          u.Host,
+		DefaultHeader: defaultHeaders,
+		Debug:         true,
+		HTTPClient:    client,
 		Servers: airflow.ServerConfigurations{
 			{
 				URL:         fmt.Sprint(path, d.Get("base_path").(string)),


### PR DESCRIPTION
Problem:
When using the Airflow provider with AWS MWAA environments configured with PRIVATE_ONLY webserver access mode, the existing oauth2_token authentication (Bearer token) does not work against the Airflow REST API (/api/v1/*).

MWAA's create-web-login-token produces a WebToken that is not a valid Bearer token for the REST API. Instead, the token must first be exchanged for a session cookie via POST /aws_mwaa/login, and subsequent API requests must use Cookie: session=<value> — not Authorization: Bearer.

This means there is currently no way to use this provider with MWAA private environments.

Solution:
Added a new optional provider attribute session_cookie that injects a Cookie: session=<value> header into every API request via the client's DefaultHeader mechanism.

```
provider "airflow" {
  base_endpoint  = "https://${data.external.mwaa_token.result.hostname}"
  session_cookie = data.external.mwaa_token.result.session
}
```
The session cookie can be obtained by exchanging the MWAA WebToken via POST /aws_mwaa/login. The session has a 12-hour TTL, compared to the 60-second WebToken.

Usage with AWS MWAA:
```
data "external" "mwaa_token" {
  program = ["bash", "-c", <<-EOT
    set -euo pipefail
    token_response=$(aws mwaa create-web-login-token \
      --name my-environment --region us-east-1 --output json)
    web_token=$(echo "$token_response" | jq -r '.WebToken')
    hostname=$(echo "$token_response"  | jq -r '.WebServerHostname')
 
    session_cookie=$(curl -s -c - -L \
      -X POST "https://$${hostname}/aws_mwaa/login" \
      -d "token=$${web_token}" \
      | awk -F'\t' '/session/ {v=$$NF} END {print v}')
 
    jq -n --arg session "$session_cookie" --arg hostname "$hostname" \
      '{"session": $session, "hostname": $hostname}'
  EOT
  ]
}

provider "airflow" {
  base_endpoint  = "https://${data.external.mwaa_token.result.hostname}"
  session_cookie = data.external.mwaa_token.result.session
}
```
Details:
- New attribute: session_cookie (optional, sensitive)
- Env var: AIRFLOW_SESSION_COOKIE
- Conflicts with: oauth2_token, username, password
- Mechanism: Sets Cookie: session=<value> in Configuration.DefaultHeader
- No changes to existing auth methods — fully backwards compatible