### PR TITLE
Declare protocol 6.0 in the registry manifest

### DIFF
--- a/terraform-registry-manifest.json
+++ b/terraform-registry-manifest.json
@@ -1,6 +1,6 @@
 {
     "version": 1,
     "metadata": {
-        "protocol_versions": ["5.0"]
+        "protocol_versions": ["6.0"]
     }
 }


### PR DESCRIPTION
## Summary

The provider migrated to terraform-plugin-framework and now serves **protocol v6** (`providerserver.Serve`), but `terraform-registry-manifest.json` still advertised `5.0`. Update it to `6.0` so the registry/Terraform protocol handshake matches the published binary.

Required before the 1.1.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)