### PR TITLE
Add validator-negative and SDKv2-upgrade test coverage

### DIFF
--- a/internal/fwprovider/resource_connection_test.go
+++ b/internal/fwprovider/resource_connection_test.go
@@ -3,6 +3,7 @@ package fwprovider
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -290,6 +291,53 @@ func TestAccAirflowConnection_extraEquivalentJSON(t *testing.T) {
 				// Same JSON, reformatted (whitespace + key order): must be a no-op.
 				Config:   testAccAirflowConnectionConfigExtra(rName, "{\n  \"c\": \"d\",\n  \"a\": \"b\"\n}"),
 				PlanOnly: true,
+			},
+		},
+	})
+}
+
+// TestAccAirflowConnection_validation covers the framework validators on the
+// connection resource (config-time, no API calls): password/password_wo
+// conflict, the password_wo/password_wo_version co-requirement, and the port
+// range bound.
+func TestAccAirflowConnection_validation(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "airflow_connection" "test" {
+  connection_id       = %[1]q
+  conn_type           = "http"
+  password            = "p"
+  password_wo         = "w"
+  password_wo_version = "1"
+}
+`, rName),
+				ExpectError: regexp.MustCompile(`Invalid Attribute Combination`),
+			},
+			{
+				Config: fmt.Sprintf(`
+resource "airflow_connection" "test" {
+  connection_id = %[1]q
+  conn_type     = "http"
+  password_wo   = "w"
+}
+`, rName),
+				ExpectError: regexp.MustCompile(`Invalid Attribute Combination`),
+			},
+			{
+				Config: fmt.Sprintf(`
+resource "airflow_connection" "test" {
+  connection_id = %[1]q
+  conn_type     = "http"
+  port          = 70000
+}
+`, rName),
+				ExpectError: regexp.MustCompile(`Invalid Attribute Value`),
 			},
 		},
 	})

--- a/internal/fwprovider/resource_role_test.go
+++ b/internal/fwprovider/resource_role_test.go
@@ -91,3 +91,35 @@ resource "airflow_role" "test" {
 }
 `, rName, action, resource)
 }
+
+// TestAccAirflowRole_upgradeFromSDKv2 guards the SDKv2 -> framework upgrade path
+// for the role's nested `action` block.
+func TestAccAirflowRole_upgradeFromSDKv2(t *testing.T) {
+	if os.Getenv("SKIP_AIRFLOW_USER_ROLES_TESTS") == "true" {
+		t.Skip("Skipping Airflow Roles and User Tests")
+	}
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "airflow_role.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckAirflowRoleCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"airflow": {VersionConstraint: "1.0.2", Source: "DrFaust92/airflow"},
+				},
+				Config: testAccAirflowRoleConfigBasic(rName, "can_read", "Audit Logs"),
+				Check:  resource.TestCheckResourceAttr(resourceName, "name", rName),
+			},
+			{
+				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+				Config:                   testAccAirflowRoleConfigBasic(rName, "can_read", "Audit Logs"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
+				),
+			},
+		},
+	})
+}

--- a/internal/fwprovider/resource_user_roles_test.go
+++ b/internal/fwprovider/resource_user_roles_test.go
@@ -185,3 +185,35 @@ func testAccPreCheckCreateUser(t *testing.T) {
 		t.Fatalf("failed to create user `%s` from Airflow: %s", username, err)
 	}
 }
+
+// TestAccAirflowUserRoles_upgradeFromSDKv2 guards the SDKv2 -> framework upgrade
+// path for airflow_user_roles (and the airflow_role it references).
+func TestAccAirflowUserRoles_upgradeFromSDKv2(t *testing.T) {
+	if os.Getenv("SKIP_AIRFLOW_USER_ROLES_TESTS") == "true" {
+		t.Skip("Skipping Airflow Roles and User Tests")
+	}
+	rName := acctest.RandomWithPrefix("tf-role-test")
+	resourceName := "airflow_user_roles.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckCreateUser(t) },
+		CheckDestroy: testAccCheckAirflowUserRolesCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"airflow": {VersionConstraint: "1.0.2", Source: "DrFaust92/airflow"},
+				},
+				Config: testAccAirflowUserRolesConfigBasic(accName, rName),
+				Check:  resource.TestCheckResourceAttr(resourceName, "username", accName),
+			},
+			{
+				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+				Config:                   testAccAirflowUserRolesConfigBasic(accName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "username", accName),
+					resource.TestCheckResourceAttr(resourceName, "roles.#", "1"),
+				),
+			},
+		},
+	})
+}

--- a/internal/fwprovider/resource_user_test.go
+++ b/internal/fwprovider/resource_user_test.go
@@ -111,3 +111,35 @@ resource "airflow_user" "test" {
 }
 `, rName, fName)
 }
+
+// TestAccAirflowUser_upgradeFromSDKv2 guards the SDKv2 -> framework upgrade path
+// for airflow_user (and the airflow_role it references).
+func TestAccAirflowUser_upgradeFromSDKv2(t *testing.T) {
+	if os.Getenv("SKIP_AIRFLOW_USER_ROLES_TESTS") == "true" {
+		t.Skip("Skipping Airflow Roles and User Tests")
+	}
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "airflow_user.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckAirflowUserCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"airflow": {VersionConstraint: "1.0.2", Source: "DrFaust92/airflow"},
+				},
+				Config: testAccAirflowUserConfigBasic(rName, rName),
+				Check:  resource.TestCheckResourceAttr(resourceName, "username", rName),
+			},
+			{
+				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+				Config:                   testAccAirflowUserConfigBasic(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "username", rName),
+					resource.TestCheckResourceAttr(resourceName, "roles.#", "1"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Summary

Closes the remaining test gaps identified after the `airflow_connection` extra regression.

### Validator coverage (connection)
`TestAccAirflowConnection_validation` — config-time validator checks (no API calls):
- `password` / `password_wo` mutual conflict
- `password_wo` requires `password_wo_version`
- `port` out-of-range (0–65535 bound)

### SDKv2 → framework upgrade coverage
`TestAccAirflow{Role,User,UserRoles}_upgradeFromSDKv2` — create with the v1.0.2 (SDKv2) provider via `ExternalProviders`, then apply with the current framework provider and assert a clean, convergent plan. This extends the upgrade-path coverage (already added for connection/variable/pool in #78) to the remaining always-on resources, guarding the SDKv2 `""`/`0` → framework `null` state-representation class.

These run live in CI's testV1 job (role/user/user_roles are skipped on Airflow v3 as usual).

> Note: `dag`/`dag_run` still have no live CI coverage (`SKIP_AIRFLOW_DAG_TESTS`) — enabling that (seeding a DAG in the test Airflow) is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)