### PR TITLE
fix: preserve connection extra value when Airflow masks secrets (#34)

### DIFF
--- a/internal/fwprovider/resource_connection.go
+++ b/internal/fwprovider/resource_connection.go
@@ -391,6 +391,11 @@ func (r *connectionResource) readInto(m *connectionResourceModel, diags *diag.Di
 		// Keep the configured/state value when it is semantically-equal JSON to
 		// what the API returns, so the post-apply value matches the plan
 		// (the API may reformat JSON).
+	case !m.Extra.IsNull() && jsonEqualIgnoringMasked(m.Extra.ValueString(), apiExtra):
+		// Airflow's SecretsMasker returns secret-like keys inside `extra` as
+		// masked placeholders (e.g. {"api_key":"***"}). When that masking is the
+		// only difference from state, keep the real state value so we neither
+		// persist "***" nor produce a perpetual diff. See GH issue #34.
 	case apiExtra != "":
 		m.Extra = types.StringValue(apiExtra)
 	case !m.Extra.IsNull():
@@ -457,4 +462,55 @@ func jsonSemanticEqual(a, b string) bool {
 		return false
 	}
 	return reflect.DeepEqual(av, bv)
+}
+
+// jsonEqualIgnoringMasked reports whether state and api are both valid JSON and
+// equal once masked placeholders in api (e.g. "***", returned by Airflow's
+// SecretsMasker for secret-like keys) are treated as equal to the corresponding
+// value in state. Non-JSON values are never equal here.
+func jsonEqualIgnoringMasked(state, api string) bool {
+	var sv, av interface{}
+	if json.Unmarshal([]byte(state), &sv) != nil || json.Unmarshal([]byte(api), &av) != nil {
+		return false
+	}
+	return reflect.DeepEqual(sv, unmaskAgainst(av, sv))
+}
+
+// unmaskAgainst returns a copy of api with every masked string leaf (non-empty
+// and consisting solely of '*') replaced by the corresponding value from state
+// when one is available, leaving all other values untouched.
+func unmaskAgainst(api, state interface{}) interface{} {
+	switch a := api.(type) {
+	case map[string]interface{}:
+		s, _ := state.(map[string]interface{})
+		out := make(map[string]interface{}, len(a))
+		for k, v := range a {
+			var sv interface{}
+			if s != nil {
+				sv = s[k]
+			}
+			out[k] = unmaskAgainst(v, sv)
+		}
+		return out
+	case []interface{}:
+		s, _ := state.([]interface{})
+		out := make([]interface{}, len(a))
+		for i, v := range a {
+			var sv interface{}
+			if s != nil && i < len(s) {
+				sv = s[i]
+			}
+			out[i] = unmaskAgainst(v, sv)
+		}
+		return out
+	case string:
+		if a != "" && strings.Trim(a, "*") == "" {
+			if s, ok := state.(string); ok && s != "" {
+				return s
+			}
+		}
+		return a
+	default:
+		return a
+	}
 }

--- a/internal/fwprovider/resource_connection_test.go
+++ b/internal/fwprovider/resource_connection_test.go
@@ -296,6 +296,39 @@ func TestAccAirflowConnection_extraEquivalentJSON(t *testing.T) {
 	})
 }
 
+// TestAccAirflowConnection_extraMaskedSecret verifies idempotency when the
+// `extra` JSON contains a secret-like key (e.g. "api_key") that Airflow's
+// SecretsMasker returns masked as "***" on read. The real configured value must
+// be preserved in state so a subsequent plan is empty. See GH issue #34.
+func TestAccAirflowConnection_extraMaskedSecret(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "airflow_connection.test"
+
+	extra := `{"api_key":"mysecretkey"}`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckAirflowConnectionCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAirflowConnectionConfigExtra(rName, extra),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "connection_id", rName),
+					// The real secret value must be kept, not the masked "***".
+					resource.TestCheckResourceAttr(resourceName, "extra", extra),
+				),
+			},
+			{
+				// Re-plan with the same config: the API returns the masked value,
+				// but the provider must not surface a diff.
+				Config:   testAccAirflowConnectionConfigExtra(rName, extra),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 // TestAccAirflowConnection_validation covers the framework validators on the
 // connection resource (config-time, no API calls): password/password_wo
 // conflict, the password_wo/password_wo_version co-requirement, and the port


### PR DESCRIPTION
## Problem

Airflow's `SecretsMasker` returns secret-like keys inside a connection's `extra` (e.g. `api_key`) as `"***"` on read. The SDKv2 provider substituted the masked value back with the real one, but that handling was **not** carried over in the plugin-framework migration (#75). As a result `readInto` wrote `"***"` into state, so:

- `apply` failed with `Provider produced inconsistent result after apply` (final state ≠ plan), and
- where it didn't, every subsequent plan showed a perpetual `"***" -> "<real value>"` diff.

This reproduces the original report in #34 on both Airflow v2 and v3.

## Fix

`readInto` now keeps the real state value for `extra` when masked placeholders are the *only* difference from the API response, mirroring the existing `password` handling. New helpers:
- `jsonEqualIgnoringMasked` — both sides valid JSON and equal once masked leaves in the API value are treated as equal to the corresponding state value.
- `unmaskAgainst` — walks the API JSON and swaps all-`*` leaves for the matching state value.

Genuine (non-masked) changes are still detected, and an empty API value still clears a previously set value.

## Test

`TestAccAirflowConnection_extraMaskedSecret` applies `extra = {"api_key":"mysecretkey"}`, asserts the real value is preserved in state (not `***`), and re-plans expecting no diff. It failed on both `testV1` and `testV2` before the fix (see the first CI run on this PR) and passes with it.

Fixes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)