### PR TITLE
feat: add team_name to connection, pool and variable resources

### DIFF
--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -40,6 +40,7 @@ resource "airflow_connection" "example" {
 - `password_wo_version` (String) Triggers update of password_wo write-only. For more info see [updating write-only attributes](https://developer.hashicorp.com/terraform/language/manage-sensitive-data/write-only)
 - `port` (Number) The port of the connection.
 - `schema` (String) The schema of the connection.
+- `team_name` (String) Team name for Airflow 3 multi-team deployments. Requires multi-team mode enabled and the team to exist; ignored on Airflow 2.
 
 ### Read-Only
 

--- a/docs/resources/pool.md
+++ b/docs/resources/pool.md
@@ -31,6 +31,7 @@ resource "airflow_pool" "example" {
 
 - `description` (String) The description of the pool.
 - `include_deferred` (Boolean) Whether to include deferred tasks when calculating open pool slots.
+- `team_name` (String) Team name for Airflow 3 multi-team deployments. Requires multi-team mode enabled and the team to exist; ignored on Airflow 2.
 
 ### Read-Only
 

--- a/docs/resources/variable.md
+++ b/docs/resources/variable.md
@@ -30,6 +30,7 @@ resource "airflow_variable" "example" {
 ### Optional
 
 - `description` (String) The variable description.
+- `team_name` (String) Team name for Airflow 3 multi-team deployments. Requires multi-team mode enabled and the team to exist; ignored on Airflow 2.
 
 ### Read-Only
 

--- a/go.mod
+++ b/go.mod
@@ -88,4 +88,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/apache/airflow-client-go/airflow => github.com/drfaust92/airflow-client-go/airflow v0.0.0-20250103045940-da4c5c1666ad
+replace github.com/apache/airflow-client-go/airflow => github.com/drfaust92/airflow-client-go/airflow v0.0.0-20260704144150-84909d8bc79b

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/drfaust92/airflow-client-go/airflow v0.0.0-20250103045940-da4c5c1666ad h1:5lZOEn4GPDtbuq5sKT4mBazqpYJiW8+T7OGiTKbunU0=
-github.com/drfaust92/airflow-client-go/airflow v0.0.0-20250103045940-da4c5c1666ad/go.mod h1:mY5OB6VEs5HWIXYjCaYJTR34CccC9uxbZxnKxl/3P28=
+github.com/drfaust92/airflow-client-go/airflow v0.0.0-20260704144150-84909d8bc79b h1:gZeOrt/1qPPRm6MgJLqzUqJPG7h5wBxxAfRvXP0Ky3Y=
+github.com/drfaust92/airflow-client-go/airflow v0.0.0-20260704144150-84909d8bc79b/go.mod h1:mY5OB6VEs5HWIXYjCaYJTR34CccC9uxbZxnKxl/3P28=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=

--- a/internal/fwprovider/resource_connection.go
+++ b/internal/fwprovider/resource_connection.go
@@ -56,6 +56,7 @@ type connectionResourceModel struct {
 	PasswordWO        types.String `tfsdk:"password_wo"`
 	PasswordWOVersion types.String `tfsdk:"password_wo_version"`
 	Extra             types.String `tfsdk:"extra"`
+	TeamName          types.String `tfsdk:"team_name"`
 }
 
 func (r *connectionResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -139,6 +140,10 @@ func (r *connectionResource) Schema(_ context.Context, _ resource.SchemaRequest,
 					suppressEquivalentJSON{},
 				},
 			},
+			"team_name": schema.StringAttribute{
+				MarkdownDescription: "Team name for Airflow 3 multi-team deployments. Requires multi-team mode enabled and the team to exist; ignored on Airflow 2.",
+				Optional:            true,
+			},
 		},
 	}
 }
@@ -196,6 +201,9 @@ func (r *connectionResource) Create(ctx context.Context, req resource.CreateRequ
 	}
 	if !plan.Extra.IsNull() {
 		conn.SetExtra(plan.Extra.ValueString())
+	}
+	if !plan.TeamName.IsNull() && !plan.TeamName.IsUnknown() {
+		conn.SetTeamName(plan.TeamName.ValueString())
 	}
 
 	if pw := r.resolvePassword(ctx, plan.Password, req.Config, &resp.Diagnostics); pw != "" {
@@ -286,6 +294,9 @@ func (r *connectionResource) Update(ctx context.Context, req resource.UpdateRequ
 		conn.SetExtra(plan.Extra.ValueString())
 	} else {
 		conn.SetExtraNil()
+	}
+	if !plan.TeamName.IsNull() && !plan.TeamName.IsUnknown() {
+		conn.SetTeamName(plan.TeamName.ValueString())
 	}
 
 	if !plan.Password.IsNull() && plan.Password.ValueString() != "" {
@@ -378,6 +389,7 @@ func (r *connectionResource) readInto(m *connectionResourceModel, diags *diag.Di
 	setOptionalString(&m.Login, conn.GetLogin())
 	setOptionalString(&m.Schema, conn.GetSchema())
 	setOptionalString(&m.Description, conn.GetDescription())
+	setOptionalString(&m.TeamName, conn.GetTeamName())
 
 	if p := conn.GetPort(); p != 0 {
 		m.Port = types.Int64Value(int64(p))

--- a/internal/fwprovider/resource_pool.go
+++ b/internal/fwprovider/resource_pool.go
@@ -43,6 +43,7 @@ type poolResourceModel struct {
 	Slots           types.Int64  `tfsdk:"slots"`
 	Description     types.String `tfsdk:"description"`
 	IncludeDeferred types.Bool   `tfsdk:"include_deferred"`
+	TeamName        types.String `tfsdk:"team_name"`
 	OccupiedSlots   types.Int64  `tfsdk:"occupied_slots"`
 	QueuedSlots     types.Int64  `tfsdk:"queued_slots"`
 	OpenSlots       types.Int64  `tfsdk:"open_slots"`
@@ -87,6 +88,11 @@ func (r *poolResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				Optional:            true,
 				Computed:            true,
 				Default:             booldefault.StaticBool(false),
+			},
+			"team_name": schema.StringAttribute{
+				MarkdownDescription: "Team name for Airflow 3 multi-team deployments. Requires multi-team mode enabled and the team to exist; ignored on Airflow 2.",
+				Optional:            true,
+				Computed:            true,
 			},
 			"occupied_slots":  schema.Int64Attribute{MarkdownDescription: "The number of slots used.", Computed: true},
 			"queued_slots":    schema.Int64Attribute{MarkdownDescription: "The number of slots with queued tasks.", Computed: true},
@@ -141,6 +147,9 @@ func (r *poolResource) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
 		pool.SetDescription(plan.Description.ValueString())
+	}
+	if !plan.TeamName.IsNull() && !plan.TeamName.IsUnknown() {
+		pool.SetTeamName(plan.TeamName.ValueString())
 	}
 
 	_, httpResp, err := r.config.ApiClient.PoolApi.PostPool(r.config.AuthContext).Pool(pool).Execute()
@@ -203,6 +212,9 @@ func (r *poolResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	} else {
 		pool.SetDescriptionNil()
 	}
+	if !plan.TeamName.IsNull() && !plan.TeamName.IsUnknown() {
+		pool.SetTeamName(plan.TeamName.ValueString())
+	}
 
 	_, httpResp, err := r.config.ApiClient.PoolApi.PatchPool(r.config.AuthContext, name).Pool(pool).Execute()
 	if err != nil {
@@ -259,6 +271,7 @@ func (r *poolResource) readInto(m *poolResourceModel, diags *diag.Diagnostics) (
 	m.Name = types.StringValue(pool.GetName())
 	m.Slots = types.Int64Value(int64(pool.GetSlots()))
 	m.IncludeDeferred = types.BoolValue(pool.GetIncludeDeferred())
+	m.TeamName = types.StringValue(pool.GetTeamName())
 	m.OccupiedSlots = types.Int64Value(int64(pool.GetOccupiedSlots()))
 	m.QueuedSlots = types.Int64Value(int64(pool.GetQueuedSlots()))
 	m.OpenSlots = types.Int64Value(int64(pool.GetOpenSlots()))

--- a/internal/fwprovider/resource_variable.go
+++ b/internal/fwprovider/resource_variable.go
@@ -42,6 +42,7 @@ type variableResourceModel struct {
 	Key         types.String `tfsdk:"key"`
 	Value       types.String `tfsdk:"value"`
 	Description types.String `tfsdk:"description"`
+	TeamName    types.String `tfsdk:"team_name"`
 }
 
 func (r *variableResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -72,6 +73,11 @@ func (r *variableResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 			},
 			"description": schema.StringAttribute{
 				MarkdownDescription: "The variable description.",
+				Optional:            true,
+				Computed:            true,
+			},
+			"team_name": schema.StringAttribute{
+				MarkdownDescription: "Team name for Airflow 3 multi-team deployments. Requires multi-team mode enabled and the team to exist; ignored on Airflow 2.",
 				Optional:            true,
 				Computed:            true,
 			},
@@ -122,6 +128,9 @@ func (r *variableResource) Create(ctx context.Context, req resource.CreateReques
 	}
 	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
 		variableReq.SetDescription(plan.Description.ValueString())
+	}
+	if !plan.TeamName.IsNull() && !plan.TeamName.IsUnknown() {
+		variableReq.SetTeamName(plan.TeamName.ValueString())
 	}
 
 	_, httpResp, err := r.config.ApiClient.VariableApi.PostVariables(r.config.AuthContext).Variable(variableReq).Execute()
@@ -182,6 +191,9 @@ func (r *variableResource) Update(ctx context.Context, req resource.UpdateReques
 	} else {
 		variableReq.SetDescription("")
 	}
+	if !plan.TeamName.IsNull() && !plan.TeamName.IsUnknown() {
+		variableReq.SetTeamName(plan.TeamName.ValueString())
+	}
 
 	_, httpResp, err := r.config.ApiClient.VariableApi.PatchVariable(r.config.AuthContext, key).Variable(variableReq).Execute()
 	if err != nil {
@@ -238,6 +250,7 @@ func (r *variableResource) readInto(m *variableResourceModel, diags *diag.Diagno
 	m.Key = types.StringValue(variable.GetKey())
 	m.Value = types.StringValue(variable.GetValue())
 	m.Description = types.StringValue(variable.GetDescription())
+	m.TeamName = types.StringValue(variable.GetTeamName())
 	return true
 }
 


### PR DESCRIPTION
Adds an optional `team_name` attribute to `airflow_connection`, `airflow_pool`, and `airflow_variable` — the Airflow 3 (v2 API) multi-team field.

## Changes
- **Client bump**: `replace` directive → the fork version that adds `TeamName` to the Connection/Pool/Variable models (DrFaust92/airflow-client-go#5).
- **Resources**: `team_name` wired through schema + Create/Update + read for all three. Connection follows its Optional + `setOptionalString` pattern; pool/variable follow their Optional+Computed pattern.
- **Docs** regenerated via `make generate`.

## Notes
- `team_name` requires Airflow 3 multi-team mode enabled and the team to exist; ignored on Airflow 2.
- **No acceptance test**: multi-team mode isn't enabled in the test Airflow, and (with it off) Airflow ignores `team_name` rather than honoring it, so it can't be meaningfully asserted E2E. Existing acctests are unaffected (the attribute is optional and unset by them).

Verified: `go build ./...`, `go vet`, and `make generate` are clean; test packages compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)