### PR TITLE
fix: clearer API error messages + failure tests

### DIFF
--- a/internal/fwprovider/errors_test.go
+++ b/internal/fwprovider/errors_test.go
@@ -1,0 +1,44 @@
+package fwprovider
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestProblemDetail(t *testing.T) {
+	cases := []struct {
+		name, body, want string
+	}{
+		{"rfc7807 detail", `{"detail":"Pool already exists","title":"Conflict","status":409}`, "Pool already exists"},
+		{"title only", `{"title":"Bad Request","status":400}`, "Bad Request"},
+		{"non-json body", "boom, not json", "boom, not json"},
+		{"empty", "", ""},
+		{"whitespace only", "  \n\t ", ""},
+	}
+	for _, c := range cases {
+		if got := problemDetail([]byte(c.body)); got != c.want {
+			t.Errorf("%s: problemDetail(%q) = %q, want %q", c.name, c.body, got, c.want)
+		}
+	}
+}
+
+func TestApiErrorDetailNonAPIError(t *testing.T) {
+	if got := apiErrorDetail(errors.New("plain error")); got != "" {
+		t.Errorf("apiErrorDetail(non-API error) = %q, want empty", got)
+	}
+}
+
+func TestClientError(t *testing.T) {
+	got := clientError("create", "my-pool", &http.Response{Status: "409 Conflict"}, errors.New("boom"))
+	for _, want := range []string{"create", `"my-pool"`, "409 Conflict", "boom"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("clientError() = %q, missing %q", got, want)
+		}
+	}
+
+	if got := clientError("read", "x", nil, nil); got != `failed to read "x"` {
+		t.Errorf("clientError(no resp/err) = %q", got)
+	}
+}

--- a/internal/fwprovider/resource_pool_test.go
+++ b/internal/fwprovider/resource_pool_test.go
@@ -2,12 +2,32 @@ package fwprovider
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
+
+// TestAccAirflowPool_errorSurfacesAPIMessage verifies that an Airflow API
+// failure surfaces as a clear, attributed error. "default_pool" always exists,
+// so creating it conflicts, exercising the client-error parsing path.
+func TestAccAirflowPool_errorSurfacesAPIMessage(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `resource "airflow_pool" "err" {
+  name  = "default_pool"
+  slots = 1
+}`,
+				ExpectError: regexp.MustCompile(`(?i)failed to create.*default_pool`),
+			},
+		},
+	})
+}
 
 func TestAccAirflowPool_basic(t *testing.T) {
 	rName := acctest.RandomWithPrefix("tf-acc-test")

--- a/internal/fwprovider/resource_variable.go
+++ b/internal/fwprovider/resource_variable.go
@@ -1,7 +1,10 @@
 package fwprovider
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -254,9 +257,55 @@ func (r *variableResource) readInto(m *variableResourceModel, diags *diag.Diagno
 	return true
 }
 
-func clientError(op, key string, httpResp *http.Response, err error) string {
+// clientError builds a diagnostic detail for a failed Airflow API call. The
+// resource type is already named in the diagnostic summary, so the detail only
+// carries the operation, the object id, the HTTP status, and -- crucially --
+// Airflow's own error message from the response body (see apiErrorDetail),
+// rather than just the bare HTTP status the client's error string exposes.
+func clientError(op, id string, httpResp *http.Response, err error) string {
+	msg := fmt.Sprintf("failed to %s %q", op, id)
 	if httpResp != nil {
-		return fmt.Sprintf("failed to %s variable %q, Status: %q from Airflow: %s", op, key, httpResp.Status, err)
+		msg += fmt.Sprintf(" (status %s)", httpResp.Status)
 	}
-	return fmt.Sprintf("failed to %s variable %q from Airflow: %s", op, key, err)
+	if detail := apiErrorDetail(err); detail != "" {
+		return msg + ": " + detail
+	}
+	if err != nil {
+		return msg + ": " + err.Error()
+	}
+	return msg
+}
+
+// apiErrorDetail extracts Airflow's error message from a client error. The
+// generated client's error string is only the HTTP status; the useful message
+// (RFC 7807 problem detail) is in the response body. Returns "" when absent.
+func apiErrorDetail(err error) string {
+	var apiErr *airflow.GenericOpenAPIError
+	if !errors.As(err, &apiErr) {
+		return ""
+	}
+	return problemDetail(apiErr.Body())
+}
+
+// problemDetail returns the human-readable message from an Airflow error
+// response body. Airflow uses RFC 7807 problem details, so prefer `detail`,
+// then `title`; fall back to the raw body for non-JSON payloads.
+func problemDetail(body []byte) string {
+	body = bytes.TrimSpace(body)
+	if len(body) == 0 {
+		return ""
+	}
+	var problem struct {
+		Detail string `json:"detail"`
+		Title  string `json:"title"`
+	}
+	if json.Unmarshal(body, &problem) == nil {
+		if problem.Detail != "" {
+			return problem.Detail
+		}
+		if problem.Title != "" {
+			return problem.Title
+		}
+	}
+	return string(body)
 }


### PR DESCRIPTION
## Problem
The shared `clientError` detail **hardcoded "variable"**, so a pool/connection/dag failure read *"failed to ... variable ..."* in the diagnostic detail. It also surfaced only the HTTP status (the client's `error` string), **not Airflow's actual message** (RFC 7807 `detail` in the response body).

## Fix
- **`clientError`**: drop the incorrect resource noun (the diagnostic *summary* already names the resource, e.g. "Failed to create Airflow pool") and append Airflow's parsed message.
- **`apiErrorDetail`/`problemDetail`**: pull the message from the `*GenericOpenAPIError` response **body** (whose `Error()` is only the status), preferring RFC 7807 `detail` → `title` → raw body.
- Signature unchanged → all ~35 call sites (resources + list resources + the new data sources) get clearer errors for free.

Before: `failed to create variable "my-pool", Status: "409 Conflict" from Airflow: 409 Conflict`
After: `failed to create "my-pool" (status 409 Conflict): Pool already exists`

## Tests (the requested failure scenarios)
- **Unit** (`errors_test.go`): `problemDetail` parsing (rfc7807 detail / title-only / non-json / empty) and `clientError` formatting. Deterministic, no cluster.
- **Acceptance**: `TestAccAirflowPool_errorSurfacesAPIMessage` — creating the always-present `default_pool` must fail with an attributed conflict error, exercising the parse path against real Airflow (runs on both testV1/testV2).

Verified: `go build`, `go vet`, `gofmt`, and the unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)