### PR TITLE
test: out-of-band deletion (disappears) coverage

### DIFF
--- a/internal/fwprovider/disappears_test.go
+++ b/internal/fwprovider/disappears_test.go
@@ -1,0 +1,119 @@
+package fwprovider
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/drfaust92/terraform-provider-airflow/internal/client"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+// disappearsDeleteFunc deletes the object behind a resource directly via the
+// Airflow API, simulating out-of-band deletion.
+type disappearsDeleteFunc func(cfg client.ProviderConfig, id string) (*http.Response, error)
+
+// testAccCheckDisappears deletes the resource's Airflow object out-of-band. Used
+// with ExpectNonEmptyPlan to assert the provider handles the deletion gracefully:
+// the next refresh must drop it from state (404 -> RemoveResource, no error) so
+// Terraform plans to recreate it, rather than erroring.
+func testAccCheckDisappears(resourceName string, del disappearsDeleteFunc) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found in state: %s", resourceName)
+		}
+		cfg, err := testAccProviderConfig()
+		if err != nil {
+			return err
+		}
+		if _, err := del(cfg, rs.Primary.ID); err != nil {
+			return fmt.Errorf("out-of-band delete of %s (%s) failed: %w", resourceName, rs.Primary.ID, err)
+		}
+		return nil
+	}
+}
+
+func TestAccAirflowVariable_disappears(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{{
+			Config: testAccAirflowVariableConfigBasic(rName, "value"),
+			Check: testAccCheckDisappears("airflow_variable.test", func(cfg client.ProviderConfig, id string) (*http.Response, error) {
+				return cfg.ApiClient.VariableApi.DeleteVariable(cfg.AuthContext, id).Execute()
+			}),
+			ExpectNonEmptyPlan: true,
+		}},
+	})
+}
+
+func TestAccAirflowConnection_disappears(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{{
+			Config: testAccAirflowConnectionConfigBasic(rName),
+			Check: testAccCheckDisappears("airflow_connection.test", func(cfg client.ProviderConfig, id string) (*http.Response, error) {
+				return cfg.ApiClient.ConnectionApi.DeleteConnection(cfg.AuthContext, id).Execute()
+			}),
+			ExpectNonEmptyPlan: true,
+		}},
+	})
+}
+
+func TestAccAirflowPool_disappears(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{{
+			Config: testAccAirflowPoolConfigBasic(rName, 1),
+			Check: testAccCheckDisappears("airflow_pool.test", func(cfg client.ProviderConfig, id string) (*http.Response, error) {
+				return cfg.ApiClient.PoolApi.DeletePool(cfg.AuthContext, id).Execute()
+			}),
+			ExpectNonEmptyPlan: true,
+		}},
+	})
+}
+
+func TestAccAirflowUser_disappears(t *testing.T) {
+	if os.Getenv("SKIP_AIRFLOW_USER_ROLES_TESTS") == "true" {
+		t.Skip("Skipping Airflow Roles and User Tests")
+	}
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{{
+			Config: testAccAirflowUserConfigBasic(rName, rName),
+			Check: testAccCheckDisappears("airflow_user.test", func(cfg client.ProviderConfig, id string) (*http.Response, error) {
+				return cfg.ApiClient.UserApi.DeleteUser(cfg.AuthContext, id).Execute()
+			}),
+			ExpectNonEmptyPlan: true,
+		}},
+	})
+}
+
+func TestAccAirflowRole_disappears(t *testing.T) {
+	if os.Getenv("SKIP_AIRFLOW_USER_ROLES_TESTS") == "true" {
+		t.Skip("Skipping Airflow Roles and User Tests")
+	}
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{{
+			Config: testAccAirflowRoleConfigBasic(rName, "can_read", "Audit Logs"),
+			Check: testAccCheckDisappears("airflow_role.test", func(cfg client.ProviderConfig, id string) (*http.Response, error) {
+				return cfg.ApiClient.RoleApi.DeleteRole(cfg.AuthContext, id).Execute()
+			}),
+			ExpectNonEmptyPlan: true,
+		}},
+	})
+}


### PR DESCRIPTION
Adds acceptance **disappears** tests: delete a resource's Airflow object out-of-band, then assert `ExpectNonEmptyPlan`. This proves the provider handles out-of-band deletion **gracefully** — on refresh a 404 drops the resource from state (`RemoveResource`, no error) and Terraform plans to recreate it, rather than erroring.

The behavior was already correct and consistent across all resources (verified: every `readInto` returns `found=false` on 404 without a diagnostic, and every `Read` does `if !found { RemoveResource }`; `Delete` is also 404-tolerant) — this locks it in with tests.

## Coverage
- **variable, connection, pool** — run on Airflow 2 & 3.
- **user, role** — gated on `SKIP_AIRFLOW_USER_ROLES_TESTS` (Airflow 2 only), matching their existing tests.
- Shared `testAccCheckDisappears` helper (deletes via the API client the checks already use).

**Not added:** `dag`/`dag_run` (their acctests are disabled in CI via `SKIP_AIRFLOW_DAG_TESTS`, so a test there never runs) and `user_roles` (an association, not a standalone object). Those Read paths share the same audited 404 handling.

Verified: `go vet` compiles the tests; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)