### PR TITLE
ci: run integration tests on push to master (+ verify current master)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: integration-test
 
-on: pull_request
+on:
+  pull_request:
+  push:
+    branches: [master]
 
 jobs:
   testV2:


### PR DESCRIPTION
The integration-test workflow only triggered on pull_request, so changes merged directly to master were never CI-verified — including the recently merged team_name, data source, error-handling, disappears and auth-error work.

- Add `push: branches: [master]` so merges to master are exercised against live Airflow 2 (v1) and 3 (v2) going forward.
- Opening this PR runs the full `make testacc` acceptance suite (testV1 + testV2) against the current master codebase for the first time.

CI configuration only; no provider code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)