### PR TITLE
feat(user): add write-only password_wo to airflow_user

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -31,9 +31,16 @@ resource "airflow_user" "example" {
 - `email` (String) The user's email.
 - `first_name` (String) The user firstname.
 - `last_name` (String) The user lastname.
-- `password` (String, Sensitive) The user password.
 - `roles` (Set of String) A set of User roles to attach to the User.
 - `username` (String) The username.
+
+### Optional
+
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
+- `password` (String, Sensitive) The user password. Exactly one of `password` or `password_wo` must be set.
+- `password_wo` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The user password. This field is write-only and is never stored in state. Requires Terraform 1.11 or later.
+- `password_wo_version` (String) Triggers update of `password_wo` write-only. For more info see [updating write-only attributes](https://developer.hashicorp.com/terraform/language/manage-sensitive-data/write-only).
 
 ### Read-Only
 

--- a/internal/fwprovider/resource_user.go
+++ b/internal/fwprovider/resource_user.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/apache/airflow-client-go/airflow"
 	"github.com/drfaust92/terraform-provider-airflow/internal/client"
+	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -15,13 +17,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 var (
-	_ resource.Resource                = &userResource{}
-	_ resource.ResourceWithConfigure   = &userResource{}
-	_ resource.ResourceWithImportState = &userResource{}
+	_ resource.Resource                     = &userResource{}
+	_ resource.ResourceWithConfigure        = &userResource{}
+	_ resource.ResourceWithImportState      = &userResource{}
+	_ resource.ResourceWithConfigValidators = &userResource{}
 )
 
 func newUserResource() resource.Resource {
@@ -33,16 +37,18 @@ type userResource struct {
 }
 
 type userResourceModel struct {
-	ID               types.String `tfsdk:"id"`
-	Active           types.Bool   `tfsdk:"active"`
-	Email            types.String `tfsdk:"email"`
-	FailedLoginCount types.Int64  `tfsdk:"failed_login_count"`
-	FirstName        types.String `tfsdk:"first_name"`
-	LastName         types.String `tfsdk:"last_name"`
-	LoginCount       types.String `tfsdk:"login_count"`
-	Roles            []string     `tfsdk:"roles"`
-	Username         types.String `tfsdk:"username"`
-	Password         types.String `tfsdk:"password"`
+	ID                types.String `tfsdk:"id"`
+	Active            types.Bool   `tfsdk:"active"`
+	Email             types.String `tfsdk:"email"`
+	FailedLoginCount  types.Int64  `tfsdk:"failed_login_count"`
+	FirstName         types.String `tfsdk:"first_name"`
+	LastName          types.String `tfsdk:"last_name"`
+	LoginCount        types.String `tfsdk:"login_count"`
+	Roles             []string     `tfsdk:"roles"`
+	Username          types.String `tfsdk:"username"`
+	Password          types.String `tfsdk:"password"`
+	PasswordWO        types.String `tfsdk:"password_wo"`
+	PasswordWOVersion types.String `tfsdk:"password_wo_version"`
 }
 
 func (r *userResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -103,12 +109,54 @@ func (r *userResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				},
 			},
 			"password": schema.StringAttribute{
-				MarkdownDescription: "The user password.",
-				Required:            true,
+				MarkdownDescription: "The user password. Exactly one of `password` or `password_wo` must be set.",
+				Optional:            true,
 				Sensitive:           true,
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.MatchRoot("password_wo")),
+				},
+			},
+			"password_wo": schema.StringAttribute{
+				MarkdownDescription: "The user password. This field is write-only and is never stored in state. Requires Terraform 1.11 or later.",
+				Optional:            true,
+				WriteOnly:           true,
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.MatchRoot("password")),
+					stringvalidator.AlsoRequires(path.MatchRoot("password_wo_version")),
+				},
+			},
+			"password_wo_version": schema.StringAttribute{
+				MarkdownDescription: "Triggers update of `password_wo` write-only. For more info see [updating write-only attributes](https://developer.hashicorp.com/terraform/language/manage-sensitive-data/write-only).",
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.AlsoRequires(path.MatchRoot("password_wo")),
+				},
 			},
 		},
 	}
+}
+
+func (r *userResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		resourcevalidator.ExactlyOneOf(
+			path.MatchRoot("password"),
+			path.MatchRoot("password_wo"),
+		),
+	}
+}
+
+// resolvePassword returns the password to send: the configured password if set,
+// otherwise the write-only password_wo value from config.
+func (r *userResource) resolvePassword(ctx context.Context, password types.String, config tfsdk.Config, diags *diag.Diagnostics) string {
+	if !password.IsNull() && password.ValueString() != "" {
+		return password.ValueString()
+	}
+	var pwWO types.String
+	diags.Append(config.GetAttribute(ctx, path.Root("password_wo"), &pwWO)...)
+	if diags.HasError() || pwWO.IsNull() || pwWO.IsUnknown() {
+		return ""
+	}
+	return pwWO.ValueString()
 }
 
 func (r *userResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
@@ -139,7 +187,10 @@ func (r *userResource) Create(ctx context.Context, req resource.CreateRequest, r
 	firstName := plan.FirstName.ValueString()
 	lastName := plan.LastName.ValueString()
 	username := plan.Username.ValueString()
-	password := plan.Password.ValueString()
+	password := r.resolvePassword(ctx, plan.Password, req.Config, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	_, httpResp, err := r.config.ApiClient.UserApi.PostUser(r.config.AuthContext).User(airflow.User{
 		Email:     &email,
@@ -185,8 +236,9 @@ func (r *userResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 }
 
 func (r *userResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var plan userResourceModel
+	var plan, state userResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -194,14 +246,29 @@ func (r *userResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	email := plan.Email.ValueString()
 	firstName := plan.FirstName.ValueString()
 	lastName := plan.LastName.ValueString()
-	password := plan.Password.ValueString()
 	username := plan.ID.ValueString()
+
+	// Only send the password when it actually changed: a configured `password`,
+	// or a `password_wo` rotation signalled by a bumped password_wo_version.
+	// Otherwise leave it nil so the existing password is preserved.
+	var passwordPtr *string
+	if !plan.Password.IsNull() && plan.Password.ValueString() != "" {
+		pw := plan.Password.ValueString()
+		passwordPtr = &pw
+	} else if !plan.PasswordWOVersion.Equal(state.PasswordWOVersion) {
+		if pw := r.resolvePassword(ctx, plan.Password, req.Config, &resp.Diagnostics); pw != "" {
+			passwordPtr = &pw
+		}
+	}
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	_, httpResp, err := r.config.ApiClient.UserApi.PatchUser(r.config.AuthContext, username).User(airflow.User{
 		Email:     &email,
 		FirstName: &firstName,
 		LastName:  &lastName,
-		Password:  &password,
+		Password:  passwordPtr,
 		Roles:     expandUserRoles(plan.Roles),
 		Username:  &username,
 	}).Execute()

--- a/internal/fwprovider/resource_user_test.go
+++ b/internal/fwprovider/resource_user_test.go
@@ -182,7 +182,7 @@ resource "airflow_user" "test" {
   roles      = ["Admin"]
 }
 `, rName),
-				ExpectError: regexp.MustCompile(`Invalid Attribute Combination`),
+				ExpectError: regexp.MustCompile(`Exactly one of these attributes must be configured`),
 			},
 		},
 	})

--- a/internal/fwprovider/resource_user_test.go
+++ b/internal/fwprovider/resource_user_test.go
@@ -3,6 +3,7 @@ package fwprovider
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -110,6 +111,104 @@ resource "airflow_user" "test" {
   roles      = [airflow_role.test.name]
 }
 `, rName, fName)
+}
+
+// TestAccAirflowUser_passwordWO creates a user with the write-only password_wo,
+// asserts the secret is never persisted to state, and that bumping
+// password_wo_version rotates it (triggers an update).
+func TestAccAirflowUser_passwordWO(t *testing.T) {
+	if os.Getenv("SKIP_AIRFLOW_USER_ROLES_TESTS") == "true" {
+		t.Skip("Skipping Airflow Roles and User Tests")
+	}
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "airflow_user.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckAirflowUserCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAirflowUserConfigPasswordWO(rName, "Mustbe8characters", 1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "username", rName),
+					resource.TestCheckResourceAttr(resourceName, "password_wo_version", "1"),
+					// write-only value must never be persisted to state
+					resource.TestCheckNoResourceAttr(resourceName, "password_wo"),
+				),
+			},
+			{
+				Config: testAccAirflowUserConfigPasswordWO(rName, "Mustbe8charactersupdated", 2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "password_wo_version", "2"),
+					resource.TestCheckNoResourceAttr(resourceName, "password_wo"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccAirflowUser_validation covers the config-time validators: exactly one
+// of password / password_wo must be set.
+func TestAccAirflowUser_validation(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "airflow_user" "test" {
+  email               = %[1]q
+  first_name          = %[1]q
+  last_name           = %[1]q
+  username            = %[1]q
+  password            = "p"
+  password_wo         = "w"
+  password_wo_version = "1"
+  roles               = ["Admin"]
+}
+`, rName),
+				ExpectError: regexp.MustCompile(`Invalid Attribute Combination`),
+			},
+			{
+				Config: fmt.Sprintf(`
+resource "airflow_user" "test" {
+  email      = %[1]q
+  first_name = %[1]q
+  last_name  = %[1]q
+  username   = %[1]q
+  roles      = ["Admin"]
+}
+`, rName),
+				ExpectError: regexp.MustCompile(`Invalid Attribute Combination`),
+			},
+		},
+	})
+}
+
+func testAccAirflowUserConfigPasswordWO(rName, password string, version int) string {
+	return fmt.Sprintf(`
+resource "airflow_role" "test" {
+  name = %[1]q
+
+  action {
+    action   = "can_read"
+    resource = "Audit Logs"
+  }
+}
+
+resource "airflow_user" "test" {
+  email               = %[1]q
+  first_name          = %[1]q
+  last_name           = %[1]q
+  username            = %[1]q
+  password_wo         = %[2]q
+  password_wo_version = %[3]d
+  roles               = [airflow_role.test.name]
+}
+`, rName, password, version)
 }
 
 // TestAccAirflowUser_upgradeFromSDKv2 guards the SDKv2 -> framework upgrade path


### PR DESCRIPTION
Extends the write-only password pattern already used on `airflow_connection` to `airflow_user`, so the user password doesn't have to be persisted in Terraform state. Requires Terraform ≥ 1.11.

## What
- New `password_wo` (write-only, never in state) + `password_wo_version` (rotation trigger).
- `password` relaxed `Required` → `Optional`; `resourcevalidator.ExactlyOneOf(password, password_wo)` keeps a password mandatory, and `stringvalidator.ConflictsWith`/`AlsoRequires` enforce the pairing (same house style as `connection`).
- **Create** sends the resolved password (`password`, else `password_wo` from config).
- **Update** sends the password only on a real change — a configured `password`, or a `password_wo` rotation signalled by a bumped `password_wo_version` — otherwise omits it (nil) so the existing password is preserved rather than reset.

## Tests / docs
- `TestAccAirflowUser_passwordWO` — create + rotate, asserting `password_wo` never lands in state (`TestCheckNoResourceAttr`).
- `TestAccAirflowUser_validation` — the exactly-one-of rule (both set / neither set both error).
- Regenerated `docs/resources/user.md`.

## Scope note
This covers `airflow_user.password` only — the clean case where the API does **not** return the secret (like `connection.password`). `airflow_variable.value` and `airflow_connection.extra` are *returned* by the Airflow API, so making them write-only requires deliberately not re-reading the secret into state on refresh; those are better handled in a separate PR.

Verified locally: `go build`, `go vet`, `gofmt`, test compile, and `make generate` (docs current). Acceptance runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)