### PR TITLE
feat(variable): add write-only value_wo to airflow_variable

### DIFF
--- a/docs/resources/variable.md
+++ b/docs/resources/variable.md
@@ -25,12 +25,16 @@ resource "airflow_variable" "example" {
 ### Required
 
 - `key` (String) The variable key.
-- `value` (String) The variable value.
 
 ### Optional
 
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
 - `description` (String) The variable description.
 - `team_name` (String) Team name for Airflow 3 multi-team deployments. Requires multi-team mode enabled and the team to exist; ignored on Airflow 2.
+- `value` (String, Sensitive) The variable value. Exactly one of `value` or `value_wo` must be set.
+- `value_wo` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The variable value. This field is write-only and is never stored in state. Requires Terraform 1.11 or later.
+- `value_wo_version` (String) Triggers update of `value_wo` write-only. For more info see [updating write-only attributes](https://developer.hashicorp.com/terraform/language/manage-sensitive-data/write-only).
 
 ### Read-Only
 

--- a/internal/fwprovider/resource_variable.go
+++ b/internal/fwprovider/resource_variable.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/apache/airflow-client-go/airflow"
 	"github.com/drfaust92/terraform-provider-airflow/internal/client"
+	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -17,14 +19,17 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 var (
-	_ resource.Resource                = &variableResource{}
-	_ resource.ResourceWithConfigure   = &variableResource{}
-	_ resource.ResourceWithImportState = &variableResource{}
-	_ resource.ResourceWithIdentity    = &variableResource{}
+	_ resource.Resource                     = &variableResource{}
+	_ resource.ResourceWithConfigure        = &variableResource{}
+	_ resource.ResourceWithImportState      = &variableResource{}
+	_ resource.ResourceWithIdentity         = &variableResource{}
+	_ resource.ResourceWithConfigValidators = &variableResource{}
 )
 
 // variableIdentityModel is the resource identity for airflow_variable (its key).
@@ -41,11 +46,13 @@ type variableResource struct {
 }
 
 type variableResourceModel struct {
-	ID          types.String `tfsdk:"id"`
-	Key         types.String `tfsdk:"key"`
-	Value       types.String `tfsdk:"value"`
-	Description types.String `tfsdk:"description"`
-	TeamName    types.String `tfsdk:"team_name"`
+	ID             types.String `tfsdk:"id"`
+	Key            types.String `tfsdk:"key"`
+	Value          types.String `tfsdk:"value"`
+	ValueWO        types.String `tfsdk:"value_wo"`
+	ValueWOVersion types.String `tfsdk:"value_wo_version"`
+	Description    types.String `tfsdk:"description"`
+	TeamName       types.String `tfsdk:"team_name"`
 }
 
 func (r *variableResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -71,8 +78,28 @@ func (r *variableResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				},
 			},
 			"value": schema.StringAttribute{
-				MarkdownDescription: "The variable value.",
-				Required:            true,
+				MarkdownDescription: "The variable value. Exactly one of `value` or `value_wo` must be set.",
+				Optional:            true,
+				Sensitive:           true,
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.MatchRoot("value_wo")),
+				},
+			},
+			"value_wo": schema.StringAttribute{
+				MarkdownDescription: "The variable value. This field is write-only and is never stored in state. Requires Terraform 1.11 or later.",
+				Optional:            true,
+				WriteOnly:           true,
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.MatchRoot("value")),
+					stringvalidator.AlsoRequires(path.MatchRoot("value_wo_version")),
+				},
+			},
+			"value_wo_version": schema.StringAttribute{
+				MarkdownDescription: "Triggers update of `value_wo` write-only. For more info see [updating write-only attributes](https://developer.hashicorp.com/terraform/language/manage-sensitive-data/write-only).",
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.AlsoRequires(path.MatchRoot("value_wo")),
+				},
 			},
 			"description": schema.StringAttribute{
 				MarkdownDescription: "The variable description.",
@@ -115,6 +142,29 @@ func (r *variableResource) Configure(_ context.Context, req resource.ConfigureRe
 	r.config = cfg
 }
 
+func (r *variableResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		resourcevalidator.ExactlyOneOf(
+			path.MatchRoot("value"),
+			path.MatchRoot("value_wo"),
+		),
+	}
+}
+
+// resolveValue returns the value to send: the configured value if set,
+// otherwise the write-only value_wo value from config.
+func (r *variableResource) resolveValue(ctx context.Context, value types.String, config tfsdk.Config, diags *diag.Diagnostics) string {
+	if !value.IsNull() && value.ValueString() != "" {
+		return value.ValueString()
+	}
+	var vWO types.String
+	diags.Append(config.GetAttribute(ctx, path.Root("value_wo"), &vWO)...)
+	if diags.HasError() || vWO.IsNull() || vWO.IsUnknown() {
+		return ""
+	}
+	return vWO.ValueString()
+}
+
 func (r *variableResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan variableResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -123,7 +173,10 @@ func (r *variableResource) Create(ctx context.Context, req resource.CreateReques
 	}
 
 	key := plan.Key.ValueString()
-	val := plan.Value.ValueString()
+	val := r.resolveValue(ctx, plan.Value, req.Config, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	variableReq := airflow.Variable{
 		Key:   &key,
@@ -182,7 +235,10 @@ func (r *variableResource) Update(ctx context.Context, req resource.UpdateReques
 	}
 
 	key := plan.ID.ValueString()
-	val := plan.Value.ValueString()
+	val := r.resolveValue(ctx, plan.Value, req.Config, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	variableReq := airflow.Variable{
 		Key:   &key,
@@ -251,7 +307,12 @@ func (r *variableResource) readInto(m *variableResourceModel, diags *diag.Diagno
 	}
 
 	m.Key = types.StringValue(variable.GetKey())
-	m.Value = types.StringValue(variable.GetValue())
+	// In write-only mode (value_wo_version set) the value came from the
+	// write-only value_wo and must not be persisted to state, so skip reading it
+	// back from the API. Otherwise refresh value from the API as before.
+	if m.ValueWOVersion.IsNull() {
+		m.Value = types.StringValue(variable.GetValue())
+	}
 	m.Description = types.StringValue(variable.GetDescription())
 	m.TeamName = types.StringValue(variable.GetTeamName())
 	return true

--- a/internal/fwprovider/resource_variable_test.go
+++ b/internal/fwprovider/resource_variable_test.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/drfaust92/terraform-provider-airflow/internal/client"
@@ -127,6 +128,82 @@ func testAccProviderConfig() (client.ProviderConfig, error) {
 		cmp.Or(os.Getenv("AIRFLOW_API_BASE_PATH"), defaultBasePath),
 		os.Getenv("AIRFLOW_SESSION_COOKIE"),
 	)
+}
+
+// TestAccAirflowVariable_valueWO creates a variable with the write-only
+// value_wo, asserts neither the write-only value nor the plain value is
+// persisted to state, and that bumping value_wo_version rotates it.
+func TestAccAirflowVariable_valueWO(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "airflow_variable.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckAirflowVariableCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAirflowVariableConfigValueWO(rName, "secret1", 1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "key", rName),
+					resource.TestCheckResourceAttr(resourceName, "value_wo_version", "1"),
+					resource.TestCheckNoResourceAttr(resourceName, "value_wo"),
+					// the secret must not be persisted via value either
+					resource.TestCheckNoResourceAttr(resourceName, "value"),
+				),
+			},
+			{
+				Config: testAccAirflowVariableConfigValueWO(rName, "secret2", 2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "value_wo_version", "2"),
+					resource.TestCheckNoResourceAttr(resourceName, "value_wo"),
+					resource.TestCheckNoResourceAttr(resourceName, "value"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccAirflowVariable_validation covers the config-time validators: exactly
+// one of value / value_wo must be set.
+func TestAccAirflowVariable_validation(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "airflow_variable" "test" {
+  key              = %[1]q
+  value            = "v"
+  value_wo         = "w"
+  value_wo_version = "1"
+}
+`, rName),
+				ExpectError: regexp.MustCompile(`Invalid Attribute Combination`),
+			},
+			{
+				Config: fmt.Sprintf(`
+resource "airflow_variable" "test" {
+  key = %[1]q
+}
+`, rName),
+				ExpectError: regexp.MustCompile(`Exactly one of these attributes must be configured`),
+			},
+		},
+	})
+}
+
+func testAccAirflowVariableConfigValueWO(rName, value string, version int) string {
+	return fmt.Sprintf(`
+resource "airflow_variable" "test" {
+  key              = %[1]q
+  value_wo         = %[2]q
+  value_wo_version = %[3]d
+}
+`, rName, value, version)
 }
 
 func testAccAirflowVariableConfigBasic(rName, value string) string {


### PR DESCRIPTION
Airflow variables frequently hold secrets, but `value` was stored in state in plaintext (and wasn't even marked `Sensitive`). This adds a write-only option. Requires Terraform ≥ 1.11.

## What
- New `value_wo` (write-only, never in state) + `value_wo_version` (rotation trigger).
- `value` relaxed `Required` → `Optional` and now marked **`Sensitive`**; `resourcevalidator.ExactlyOneOf(value, value_wo)` keeps a value mandatory, with `ConflictsWith`/`AlsoRequires` enforcing the pairing.
- Create/Update send the resolved value (`value`, else `value_wo` from config — which is present on every apply).

## Read-back handling (the tricky bit)
Unlike passwords, the Airflow **API returns the variable value** on GET. To avoid the write-only secret leaking back into state on refresh, `readInto` skips refreshing `value` when in write-only mode (detected by `value_wo_version` being set). Plain `value` variables refresh as before, so import/drift detection is unchanged for them.

## Tests / docs
- `TestAccAirflowVariable_valueWO` — create + rotate, asserting neither `value_wo` nor `value` is persisted to state.
- `TestAccAirflowVariable_validation` — the exactly-one-of rule (both set / neither set).
- Regenerated `docs/resources/variable.md`.

Verified locally: `go build`, `go vet`, `gofmt`, test compile, `make generate`. Acceptance runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)