### PR TITLE
fix(variable): keep real value when Airflow masks a secret variable (#83)

### DIFF
--- a/internal/fwprovider/resource_variable.go
+++ b/internal/fwprovider/resource_variable.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/apache/airflow-client-go/airflow"
 	"github.com/drfaust92/terraform-provider-airflow/internal/client"
@@ -311,11 +312,26 @@ func (r *variableResource) readInto(m *variableResourceModel, diags *diag.Diagno
 	// write-only value_wo and must not be persisted to state, so skip reading it
 	// back from the API. Otherwise refresh value from the API as before.
 	if m.ValueWOVersion.IsNull() {
-		m.Value = types.StringValue(variable.GetValue())
+		// Airflow's SecretsMasker returns the value of a secret-like variable (a
+		// key matching a sensitive pattern, e.g. *_PASSWORD) as a masked
+		// placeholder like "***". Keep the real state value in that case,
+		// otherwise Terraform reports an inconsistent result after apply / a
+		// perpetual diff. See #83.
+		if apiValue := variable.GetValue(); isMaskedValue(apiValue) && !m.Value.IsNull() {
+			// keep m.Value as-is
+		} else {
+			m.Value = types.StringValue(apiValue)
+		}
 	}
 	m.Description = types.StringValue(variable.GetDescription())
 	m.TeamName = types.StringValue(variable.GetTeamName())
 	return true
+}
+
+// isMaskedValue reports whether s is an Airflow SecretsMasker placeholder — a
+// non-empty string consisting solely of '*' (e.g. "***").
+func isMaskedValue(s string) bool {
+	return s != "" && strings.Trim(s, "*") == ""
 }
 
 // clientError builds a diagnostic detail for a failed Airflow API call. The

--- a/internal/fwprovider/resource_variable_test.go
+++ b/internal/fwprovider/resource_variable_test.go
@@ -90,6 +90,37 @@ func TestAccAirflowVariable_desc(t *testing.T) {
 	})
 }
 
+// TestAccAirflowVariable_maskedSecret covers GH #83: Airflow's SecretsMasker
+// returns the value of a secret-like variable (key matching a sensitive
+// pattern) as "***" on read. The provider must keep the real state value
+// rather than persisting the mask, which otherwise causes an inconsistent
+// result after apply / a perpetual diff.
+func TestAccAirflowVariable_maskedSecret(t *testing.T) {
+	// A key containing "password" triggers Airflow's masking of the value.
+	rName := acctest.RandomWithPrefix("tf-acc-test") + "_password"
+	resourceName := "airflow_variable.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckAirflowVariableCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAirflowVariableConfigBasic(rName, "supersecret"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "key", rName),
+					resource.TestCheckResourceAttr(resourceName, "value", "supersecret"),
+				),
+			},
+			{
+				// Re-apply must be a no-op: the masked read-back must not diff.
+				Config:   testAccAirflowVariableConfigBasic(rName, "supersecret"),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAirflowVariableCheckDestroy(s *terraform.State) error {
 	cfg, err := testAccProviderConfig()
 	if err != nil {


### PR DESCRIPTION
Fixes #83.

## Problem
Airflow's SecretsMasker returns the value of a secret-like variable — one whose **key** matches a sensitive pattern (e.g. `DB_QUOTES_PASSWORD`) — as a masked placeholder (`***`) on read. The `airflow_variable` `readInto` persisted that mask, so Terraform errored:

```
Provider produced inconsistent result after apply:
.value: was cty.StringVal("test"), but now cty.StringVal("***")
```

(reported on 1.2.1 and 1.3.1).

## Fix
When the API returns a masked placeholder, keep the real value already in state instead of persisting the mask — mirroring the existing `connection.extra` masked-secret handling. This composes with the write-only `value_wo` guard (the read-back is still skipped entirely in write-only mode).

## Test
`TestAccAirflowVariable_maskedSecret` creates a variable with a secret-like key (`..._password`, which Airflow masks) and asserts the value survives apply and re-plans cleanly.

Verified locally: `go build`, `go vet`, `gofmt`, test compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)