### PR TITLE
docs(list-resources): add descriptions so registry pages aren't blank

### DIFF
--- a/docs/list-resources/connection.md
+++ b/docs/list-resources/connection.md
@@ -3,12 +3,12 @@
 page_title: "airflow_connection List Resource - airflow"
 subcategory: ""
 description: |-
-  
+  Lists all Airflow connections. Use with terraform query (Terraform 1.14 and later) to enumerate existing connections.
 ---
 
 # airflow_connection (List Resource)
 
-
+Lists all Airflow connections. Use with `terraform query` (Terraform 1.14 and later) to enumerate existing connections.
 
 
 

--- a/docs/list-resources/pool.md
+++ b/docs/list-resources/pool.md
@@ -3,12 +3,12 @@
 page_title: "airflow_pool List Resource - airflow"
 subcategory: ""
 description: |-
-  
+  Lists all Airflow pools. Use with terraform query (Terraform 1.14 and later) to enumerate existing pools.
 ---
 
 # airflow_pool (List Resource)
 
-
+Lists all Airflow pools. Use with `terraform query` (Terraform 1.14 and later) to enumerate existing pools.
 
 
 

--- a/docs/list-resources/variable.md
+++ b/docs/list-resources/variable.md
@@ -3,12 +3,12 @@
 page_title: "airflow_variable List Resource - airflow"
 subcategory: ""
 description: |-
-  
+  Lists all Airflow variables. Use with terraform query (Terraform 1.14 and later) to enumerate existing variables.
 ---
 
 # airflow_variable (List Resource)
 
-
+Lists all Airflow variables. Use with `terraform query` (Terraform 1.14 and later) to enumerate existing variables.
 
 
 

--- a/internal/fwprovider/resource_connection_list.go
+++ b/internal/fwprovider/resource_connection_list.go
@@ -30,7 +30,9 @@ func (r *connectionListResource) Metadata(_ context.Context, req resource.Metada
 }
 
 func (r *connectionListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, resp *list.ListResourceSchemaResponse) {
-	resp.Schema = listschema.Schema{}
+	resp.Schema = listschema.Schema{
+		MarkdownDescription: "Lists all Airflow connections. Use with `terraform query` (Terraform 1.14 and later) to enumerate existing connections.",
+	}
 }
 
 func (r *connectionListResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {

--- a/internal/fwprovider/resource_pool_list.go
+++ b/internal/fwprovider/resource_pool_list.go
@@ -30,7 +30,9 @@ func (r *poolListResource) Metadata(_ context.Context, req resource.MetadataRequ
 }
 
 func (r *poolListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, resp *list.ListResourceSchemaResponse) {
-	resp.Schema = listschema.Schema{}
+	resp.Schema = listschema.Schema{
+		MarkdownDescription: "Lists all Airflow pools. Use with `terraform query` (Terraform 1.14 and later) to enumerate existing pools.",
+	}
 }
 
 func (r *poolListResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {

--- a/internal/fwprovider/resource_variable_list.go
+++ b/internal/fwprovider/resource_variable_list.go
@@ -31,7 +31,9 @@ func (r *variableListResource) Metadata(_ context.Context, req resource.Metadata
 
 func (r *variableListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, resp *list.ListResourceSchemaResponse) {
 	// No filter arguments: list all variables.
-	resp.Schema = listschema.Schema{}
+	resp.Schema = listschema.Schema{
+		MarkdownDescription: "Lists all Airflow variables. Use with `terraform query` (Terraform 1.14 and later) to enumerate existing variables.",
+	}
 }
 
 func (r *variableListResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {


### PR DESCRIPTION
The list resources (`airflow_connection`/`pool`/`variable`) render as **blank pages** on the registry because each declared an empty `listschema.Schema{}` with no `MarkdownDescription` — tfplugindocs had nothing to emit.

## Fix
Add a `MarkdownDescription` to each list resource's `ListResourceConfigSchema` and regenerate docs. Confirmed the description now flows into the generated `docs/list-resources/*.md` (frontmatter + body).

The `## Schema` section stays empty by design — list resources take no configuration arguments (they enumerate all objects); that's correct, not a gap.

Note: unrelated to tfplugindocs#584 (that's about `validate` silently passing when a list doc dir is *missing*); generation works fine on v0.25.0 — we simply never supplied descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)