### PR TITLE
fix(provider): configure list resources (they panicked); add airflow_pool list test

### DIFF
--- a/internal/fwprovider/provider.go
+++ b/internal/fwprovider/provider.go
@@ -123,6 +123,9 @@ func (p *airflowProvider) Configure(_ context.Context, req fwprovider.ConfigureR
 
 	resp.ResourceData = cfg
 	resp.DataSourceData = cfg
+	// List resources receive their provider data from a separate field; without
+	// this they are never configured and panic on the first API call.
+	resp.ListResourceData = cfg
 }
 
 func (p *airflowProvider) Resources(_ context.Context) []func() resource.Resource {

--- a/internal/fwprovider/resource_pool_test.go
+++ b/internal/fwprovider/resource_pool_test.go
@@ -7,7 +7,10 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
 // TestAccAirflowPool_errorSurfacesAPIMessage verifies that an Airflow API
@@ -165,6 +168,42 @@ func testAccCheckAirflowPoolCheckDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+// TestAccAirflowPool_list exercises the airflow_pool list resource: it creates a
+// pool, then runs a query and asserts the created pool appears in the results.
+// List/query resources require Terraform 1.14+, so the test skips below that.
+func TestAccAirflowPool_list(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckAirflowPoolCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAirflowPoolConfigBasic(rName, 3),
+			},
+			{
+				Query: true,
+				Config: `
+provider "airflow" {}
+
+list "airflow_pool" "test" {
+  provider = airflow
+}
+`,
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectIdentity("airflow_pool.test", map[string]knownvalue.Check{
+						"id": knownvalue.StringExact(rName),
+					}),
+				},
+			},
+		},
+	})
 }
 
 func testAccAirflowPoolConfigBasic(rName string, slots int) string {


### PR DESCRIPTION
## The bug (found by the new test)
The provider's `Configure` set `ResourceData` and `DataSourceData` but **not `ListResourceData`**. terraform-plugin-framework routes provider data to **list** resources through the separate `provider.ConfigureResponse.ListResourceData` field, so the list resources (`airflow_connection`/`pool`/`variable`) were **never configured** — their API client was nil and `List` panicked (nil pointer deref) on the first call. With no list-resource tests, this went unnoticed: any `terraform query` against these would have panicked.

## Fix
Set `resp.ListResourceData = cfg` in the provider `Configure` (one line).

## Test
Adds the first list-resource acceptance test — `TestAccAirflowPool_list`: create a pool, run a `Query` step with a `list "airflow_pool" "test"` block, and assert the pool appears via `querycheck.ExpectIdentity`. This is exactly what surfaced the panic; it now exercises the configured path. Gated with `tfversion.SkipBelow(1.14)` since list/query resources need Terraform 1.14+.

Verified locally: `go build`, `go vet`, `gofmt`, test compile.