### PR TITLE
fix: preserve variable value when Airflow masks JSON leaves (#96)

### DIFF
--- a/internal/fwprovider/resource_variable.go
+++ b/internal/fwprovider/resource_variable.go
@@ -312,14 +312,25 @@ func (r *variableResource) readInto(m *variableResourceModel, diags *diag.Diagno
 	// write-only value_wo and must not be persisted to state, so skip reading it
 	// back from the API. Otherwise refresh value from the API as before.
 	if m.ValueWOVersion.IsNull() {
-		// Airflow's SecretsMasker returns the value of a secret-like variable (a
-		// key matching a sensitive pattern, e.g. *_PASSWORD) as a masked
-		// placeholder like "***". Keep the real state value in that case,
-		// otherwise Terraform reports an inconsistent result after apply / a
-		// perpetual diff. See #83.
-		if apiValue := variable.GetValue(); isMaskedValue(apiValue) && !m.Value.IsNull() {
-			// keep m.Value as-is
-		} else {
+		// Airflow's SecretsMasker replaces secret-like values with a masked
+		// placeholder like "***" on read. Keep the real state value whenever
+		// masking is the only difference from what we sent, otherwise Terraform
+		// reports an inconsistent result after apply / a perpetual diff.
+		apiValue := variable.GetValue()
+		switch {
+		case m.Value.IsNull():
+			m.Value = types.StringValue(apiValue)
+		case isMaskedValue(apiValue):
+			// The whole value is masked (a scalar secret variable, e.g. a key
+			// matching *_PASSWORD). Keep m.Value as-is. See #83.
+		case jsonSemanticEqual(m.Value.ValueString(), apiValue):
+			// The API reformatted equivalent JSON; keep the state value so the
+			// post-apply value matches the plan.
+		case jsonEqualIgnoringMasked(m.Value.ValueString(), apiValue):
+			// The value is a JSON document and the masker redacted only some of
+			// its leaves (e.g. {"a":"***"}). Masking is the only difference, so
+			// keep the real state value. See #96.
+		default:
 			m.Value = types.StringValue(apiValue)
 		}
 	}

--- a/internal/fwprovider/resource_variable_test.go
+++ b/internal/fwprovider/resource_variable_test.go
@@ -121,6 +121,42 @@ func TestAccAirflowVariable_maskedSecret(t *testing.T) {
 	})
 }
 
+// TestAccAirflowVariable_maskedJSONSecret covers GH #96: when the value is a
+// JSON document, Airflow's SecretsMasker redacts only the secret-like leaves
+// (e.g. the "password" key) rather than the whole value. The provider must keep
+// the real state value in that case too, otherwise apply fails with
+// "inconsistent values for sensitive attribute" (the whole-string mask check
+// alone does not catch a partially-masked JSON value).
+func TestAccAirflowVariable_maskedJSONSecret(t *testing.T) {
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "airflow_variable.test"
+
+	// A JSON value with a sensitive sub-key ("password") that Airflow masks
+	// per-leaf, alongside a non-sensitive leaf that is returned verbatim.
+	value := `{"password":"supersecret","queue":"data_batch_job"}`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckAirflowVariableCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAirflowVariableConfigBasic(rName, value),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "key", rName),
+					// The real value must be kept, not the partially-masked read-back.
+					resource.TestCheckResourceAttr(resourceName, "value", value),
+				),
+			},
+			{
+				// Re-apply must be a no-op: the partially-masked read-back must not diff.
+				Config:   testAccAirflowVariableConfigBasic(rName, value),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func testAccCheckAirflowVariableCheckDestroy(s *terraform.State) error {
 	cfg, err := testAccProviderConfig()
 	if err != nil {
@@ -284,4 +320,49 @@ func TestAccAirflowVariable_upgradeFromSDKv2(t *testing.T) {
 			},
 		},
 	})
+}
+
+// TestVariableValueMaskPreserved is a unit test for GH #96: a variable whose
+// value is a JSON document where Airflow's SecretsMasker redacts only some
+// leaves (not the whole value). The whole-string isMaskedValue check misses
+// this, so readInto relies on jsonEqualIgnoringMasked to detect that masking is
+// the only difference and keep the real state value, avoiding an "inconsistent
+// values for sensitive attribute" error after apply.
+func TestVariableValueMaskPreserved(t *testing.T) {
+	// The value from #96.
+	state := `{"root.data": {"batch":"data_batch_job", "stream":"data_stream_job"}}`
+
+	cases := map[string]struct {
+		api           string
+		wantWholeMask bool // isMaskedValue matches
+		wantJSONMask  bool // jsonEqualIgnoringMasked matches (masking-only diff)
+	}{
+		"partial leaf masked": {
+			api:          `{"root.data": {"batch":"data_batch_job", "stream":"***"}}`,
+			wantJSONMask: true,
+		},
+		"all leaves masked": {
+			api:          `{"root.data": {"batch":"***", "stream":"***"}}`,
+			wantJSONMask: true,
+		},
+		"whole value masked": {
+			api:           `***`,
+			wantWholeMask: true,
+		},
+		"genuinely changed value is not treated as masked": {
+			api:          `{"root.data": {"batch":"data_batch_job", "stream":"other_job"}}`,
+			wantJSONMask: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := isMaskedValue(tc.api); got != tc.wantWholeMask {
+				t.Errorf("isMaskedValue(%q) = %v, want %v", tc.api, got, tc.wantWholeMask)
+			}
+			if got := jsonEqualIgnoringMasked(state, tc.api); got != tc.wantJSONMask {
+				t.Errorf("jsonEqualIgnoringMasked(state, %q) = %v, want %v", tc.api, got, tc.wantJSONMask)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## What

Fixes #96 (a reopen of #83, which only fixed the whole-value case).

When an `airflow_variable`'s `value` is a JSON document, Airflow's `SecretsMasker` redacts only the *secret-like leaves* (e.g. `{"password":"***","queue":"x"}`) rather than the whole value. The whole-string `isMaskedValue` check added in #83 misses this, so the partially-masked JSON was written to state and no longer matched the planned sensitive value — apply failed with:

```
Error: Provider produced inconsistent result after apply
... .value: inconsistent values for sensitive attribute.
```

## How

`readInto` now reuses the connection resource's JSON-aware masking helpers (`jsonSemanticEqual` / `jsonEqualIgnoringMasked`, added on this line of work for connection #34). The real state value is kept whenever the only difference from the API is:

- a fully-masked scalar (`"***"`) — the original #83 case,
- masked leaves inside otherwise-equal JSON — the #96 case, or
- JSON reformatting.

A genuinely changed value still falls through and updates state, so real drift is detected.

## Tests

- `TestVariableValueMaskPreserved` — unit test using #96's exact JSON value (partial-leaf, all-leaves, whole-value, and genuinely-changed cases).
- `TestAccAirflowVariable_maskedJSONSecret` — acceptance test reproducing per-leaf JSON masking and asserting re-apply is a no-op.

`go build ./...`, `go vet`, and the non-acceptance test suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)